### PR TITLE
preventing last byte (00)

### DIFF
--- a/examples/ttn-abp-au/ttn-abp-au.ino
+++ b/examples/ttn-abp-au/ttn-abp-au.ino
@@ -148,7 +148,7 @@ void do_send(osjob_t* j){
         Serial.println(F("OP_TXRXPEND, not sending"));
     } else {
         // Prepare upstream data transmission at the next possible time.
-        LMIC_setTxData2(1, mydata, sizeof(mydata), 0);
+        LMIC_setTxData2(1, mydata, sizeof(mydata)-1, 0);
         Serial.println(F("Packet queued"));
     }
     // Next TX is scheduled after TX_COMPLETE event.


### PR DESCRIPTION
sizeof(mydata) will send one byte too much. resulting in having 00 appended to all data-packages sendt